### PR TITLE
Fix shared link item order

### DIFF
--- a/order.html
+++ b/order.html
@@ -375,23 +375,43 @@
             return;
         }
 
-        try {
-            const response = await fetch(`https://5000-is20x6ners704x6gl1at6-16b15953.manusvm.computer/api/orders/${orderId}`);
-            
-            if (!response.ok) {
-                throw new Error('Order not found');
-            }
+        const apiUrl = `https://5000-is20x6ners704x6gl1at6-16b15953.manusvm.computer/api/orders/${orderId}`;
 
-            const order = await response.json();
-            displayOrderData(order);
-            
+        // Try primary API with timeout, then fallback to local db.json for Netlify previews
+        try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 6000);
+            const response = await fetch(apiUrl, { signal: controller.signal, mode: 'cors' });
+            clearTimeout(timeoutId);
+
+            if (response.ok) {
+                const order = await response.json();
+                displayOrderData(order);
+                return;
+            }
         } catch (error) {
-            console.error('Error loading order:', error);
+            console.warn('Primary API failed. Falling back to static db.json', error);
+        }
+
+        // Fallback: use static db.json (works on Netlify deploy previews)
+        try {
+            const localResponse = await fetch('db.json', { cache: 'no-cache' });
+            if (!localResponse.ok) throw new Error('db.json not accessible');
+            const db = await localResponse.json();
+            const order = (db.orders || []).find(o => o.id === orderId);
+            if (order) {
+                displayOrderData(order);
+                return;
+            }
+            showError();
+        } catch (fallbackError) {
+            console.error('Fallback failed:', fallbackError);
             showError();
         }
     }
 
     function displayOrderData(order) {
+        if (!order) { showError(); return; }
         // Hide loading screen
         document.getElementById('loadingScreen').classList.add('hidden');
         


### PR DESCRIPTION
Prevent order page from infinite loading by adding API timeout and `db.json` fallback.

Previously, the order page could get stuck on a loading screen if the remote API was unreachable (e.g., on Netlify previews). This change adds a timeout for the primary API call and falls back to `db.json` if the API fails, ensuring the page either displays data or an error.

---
<a href="https://cursor.com/background-agent?bcId=bc-926bd348-6fba-4773-921f-08eb46c8dd91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-926bd348-6fba-4773-921f-08eb46c8dd91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

